### PR TITLE
Feat: [004-TOKEN-PROVIDER] "(추가) 로그인 하면 jwt token 발행"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 /logs
+/src/main/java/shop/jnjeaaaat/easyrsv/config/secret/Secret.java

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 //    implementation 'org.springframework.security:spring-security-crypto:5.7.1'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/shop/jnjeaaaat/easyrsv/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/config/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package shop.jnjeaaaat.easyrsv.config.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import shop.jnjeaaaat.easyrsv.utils.JwtTokenProvider;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtTokenProvider.resolveToken(request);
+        log.info("[doFilterInternal] token 값 추출 완료. token : {}", token);
+
+        log.info("[doFilterInternal] token 값 유효성 체크 시작");
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("[doFilterInternal] token 값 유효성 체크 완료");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package shop.jnjeaaaat.easyrsv.config.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.info("[handle] 접근이 막혔을 경우 경로 리다이렉트");
+        response.sendRedirect("/easy-rsv/v1/sign/api/exception");
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package shop.jnjeaaaat.easyrsv.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import shop.jnjeaaaat.easyrsv.domain.dto.security.EntryPointErrorResponse;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        log.info("[commence] 인증 실패로 response.sendError 발생");
+
+        EntryPointErrorResponse entryPointErrorResponse = new EntryPointErrorResponse();
+        entryPointErrorResponse.setMsg("인증이 실패하였습니다.");
+
+        response.setStatus(401);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(entryPointErrorResponse));
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/config/security/SecurityConfig.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/config/security/SecurityConfig.java
@@ -1,0 +1,82 @@
+package shop.jnjeaaaat.easyrsv.config.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import shop.jnjeaaaat.easyrsv.config.filter.JwtAuthenticationFilter;
+import shop.jnjeaaaat.easyrsv.utils.JwtTokenProvider;
+
+@Configuration
+//@EnableWebSecurity
+//@RequiredArgsConstructor
+@Slf4j
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Bean
+    public PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.httpBasic().disable()
+
+                .csrf().disable()
+
+                .sessionManagement()
+                .sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS
+                )
+
+                .and()
+                .authorizeRequests()
+                .antMatchers("/**/sign-up").permitAll()
+                .antMatchers("/**/sign-in").permitAll()
+                .antMatchers("/admin/**").permitAll()
+
+                .antMatchers("**exception**").permitAll()
+
+                .anyRequest().hasRole("ADMIN")
+
+                .and()
+                .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())
+                .and()
+                .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                ;
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring()
+                .antMatchers(
+                        "/swagger-resources/**",
+                        "/swagger-ui.html",
+                        "/webjars/**",
+                        "/swagger/**",
+                        "/easy-rsv/v1/sign/api/exception"
+                );
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/security/EntryPointErrorResponse.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/security/EntryPointErrorResponse.java
@@ -1,0 +1,12 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.security;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class EntryPointErrorResponse {
+    private String msg;
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/utils/Aes256Util.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/utils/Aes256Util.java
@@ -1,0 +1,47 @@
+package shop.jnjeaaaat.easyrsv.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import shop.jnjeaaaat.easyrsv.config.secret.Secret;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class Aes256Util {
+    public static String alg = "AES/CBC/PKCS5Padding";
+    private static final String IV = Secret.KEY.substring(0, 16);
+
+    public static String encrypt(String text) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(Secret.KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParameterSpec);
+            byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+            return Base64.encodeBase64String(encrypted);
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static String decrypt(String cipherText) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(Secret.KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] decodedBytes = Base64.decodeBase64(cipherText);
+            byte[] decrypted = cipher.doFinal(decodedBytes);
+            return new String(decrypted, StandardCharsets.UTF_8);
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/utils/JwtTokenProvider.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/utils/JwtTokenProvider.java
@@ -1,0 +1,123 @@
+package shop.jnjeaaaat.easyrsv.utils;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final UserDetailsService userDetailsService;
+
+    @Value(value = "${jwt.token.key}")
+    private String secretKey = "secretKey";
+
+    private long expireTimeMs = 1000L * 60 * 60 * 24 * 365;
+
+    @PostConstruct
+    protected void init() {
+        log.info("[init] JwtTokenProvider 내 secretKey 초기화 시작");
+        secretKey = Base64
+                .getEncoder()
+                .encodeToString(secretKey.getBytes(StandardCharsets.UTF_8));
+
+        log.info("[init] JwtTokenProvider 내 secretKey 초기화 완료");
+    }
+
+    /*
+    userId 값으로 token 발행
+    @return String
+     */
+    public String createToken(String userEmail, List<String> roles) {
+        log.info("[createToken] 토큰 생성 시작");
+        Claims claims = Jwts.claims()
+                .setSubject(Aes256Util.encrypt(userEmail)); // 일종의 map
+        claims.put("roles", roles);
+
+        Date now = new Date(System.currentTimeMillis());
+
+        String token = Jwts.builder()       // 토큰 생성
+                .setClaims(claims)
+                .setIssuedAt(now)      //  시작 시간 : 현재 시간기준으로 만들어짐
+                .setExpiration(new Date(now.getTime() + expireTimeMs))     // 끝나는 시간 : 지금 시간 + 유지할 시간(입력받아옴)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+        log.info("[createToken] 토큰 생성 완료");
+        return token;
+    }
+
+    /*
+    토큰 인증 정보 조회
+     */
+    public Authentication getAuthentication(String token) {
+        log.info("[getAuthentication] 토큰 인증 정보 조회 시작");
+        UserDetails userDetails =
+                userDetailsService.loadUserByUsername(this.getUsername(token));
+        log.info("[getAuthentication] 토큰 인증 정보 조회 완료, UserDetails Username : {}", userDetails.getUsername());
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities()
+        );
+    }
+
+    /*
+    token 으로 email 추출
+     */
+    private String getUsername(String token) {
+        log.info("[getUsername] 토큰 기반 회원 email 추출");
+        String info = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        log.info("[getUsername] 토큰 기반 회원 email 추출 완료, info : {}", info);
+        return info;
+    }
+
+    /*
+    헤더로부터 token 추출
+     */
+    public String resolveToken(HttpServletRequest request) {
+        log.info("[resolveToken] HTTP 헤더에서 Token 값 추출");
+        return request.getHeader("X-AUTH-TOKEN");
+    }
+
+    /*
+    토큰 유효성 체크
+     */
+    public boolean validateToken(String token) {
+        log.info("[validateToken] 토큰 유효 체크 시작");
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.info("[validateToken] 토큰 유효 체크 예외 발생");
+            return false;
+        }
+    }
+
+
+
+}

--- a/src/test/java/shop/jnjeaaaat/easyrsv/util/Aes256UtilTest.java
+++ b/src/test/java/shop/jnjeaaaat/easyrsv/util/Aes256UtilTest.java
@@ -1,0 +1,16 @@
+package shop.jnjeaaaat.easyrsv.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import shop.jnjeaaaat.easyrsv.utils.Aes256Util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Aes256UtilTest {
+
+    @Test
+    void encrypt() {
+        String encrypt = Aes256Util.encrypt("Hello world");
+        assertEquals("Hello world", Aes256Util.decrypt(encrypt));
+    }
+}


### PR DESCRIPTION
Changes
---
TokenProvider, Filter, Security
1. TokenProvider.class
   - createToken()
   - resolve()
   - validateToken()
2. Filter
   - tokenProvider 객체로
   - 헤더로 들어오는 token Filter
3. Security
   - 회원가입, 로그인을 제외한 api 인증, 인가 기능
   - token값이 유효하지 않을때, 인증이 실패했을 때 Handling

Fixes: #3

Background
---
로그인 했을 때 토큰 발행을 하고자 했는데

`Security`까지 적용해서 인증, 인가 기능을 추가하고
추후에 "파트너" 사용자만 상점등록 기능을 이용할 수 있게 하기 위함.

Discuss
---
토큰발행, Filter적용, Security 적용 기능을 구현해본적이 없어서 막막했는데
마침 Springboot 관련 책이 있어서 따라해서 해결했다.

참고의 도움을 적게 하고 익숙해지려면 많이 작성해봐야겠다.