### PR TITLE
Feat: [008-USER-MODIFY] "(추가) 유저 정보 수정"

### DIFF
--- a/src/main/java/shop/jnjeaaaat/easyrsv/config/security/SecurityConfig.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/config/security/SecurityConfig.java
@@ -52,11 +52,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 
                 // 유저 관련 API
-                .antMatchers("/easy-rsv/v1/user/**").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/easy-rsv/v1/user/**").hasAnyRole("USER")
 
                 // 상점 관련 API
-                .antMatchers(HttpMethod.GET, "/easy-rsv/v1/shop/**").hasAnyRole("USER", "ADMIN")
-                .antMatchers(HttpMethod.POST, "/easy-rsv/v1/shop").hasAnyRole("PARTNER", "ADMIN")
+                .antMatchers(HttpMethod.GET, "/easy-rsv/v1/shop/**").hasAnyRole("USER")
+                .antMatchers(HttpMethod.POST, "/easy-rsv/v1/shop").hasAnyRole("PARTNER")
 
                 .antMatchers("**exception**").permitAll()
 

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponse.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponse.java
@@ -5,9 +5,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @JsonPropertyOrder({"message", "result"})
 public class BaseResponse<T> {

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponseStatus.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponseStatus.java
@@ -21,11 +21,12 @@ public enum BaseResponseStatus {
     SUCCESS_ADD_ADMIN_AUTH(OK.value(), "관리자 계정이 되었습니다."),
     SUCCESS_ADD_PARTNER_AUTH(OK.value(), "이지랩 파트너가 되었습니다."),
 
+    SUCCESS_MODIFY_USER(OK.value(), "유저 정보를 수정하였습니다."),
+
 
     //// Exception
     // shop
     SHOP_NOT_FOUND(BAD_REQUEST.value(), "해당 상점이 없습니다."),
-    USER_UN_MATCH(BAD_REQUEST.value(), "유저가 일치하지 않습니다."),
 
     // user
     USER_NOT_FOUND(BAD_REQUEST.value(), "해당 유저가 없습니다."),
@@ -34,10 +35,10 @@ public enum BaseResponseStatus {
     ALREADY_ADMIN_ACCOUNT(BAD_REQUEST.value(), "이미 관리자 계정입니다."),
     ALREADY_PARTNER_ACCOUNT(BAD_REQUEST.value(), "이미 이지랩 파트너 입니다."),
 
-
     // token
     EMPTY_JWT(UNAUTHORIZED.value(), "토큰을 등록해주세요."),
     INVALID_JWT(UNAUTHORIZED.value(), "인증되지 않은 토큰입니다."),
+    USER_UN_MATCH(BAD_REQUEST.value(), "권한이 없는 유저입니다."),
 
     // access denied
     ACCESS_DENIED(FORBIDDEN.value(), "접근이 금지되었습니다."),

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/user/UserModifyRequest.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/user/UserModifyRequest.java
@@ -1,0 +1,20 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.user;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserModifyRequest {
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String name;
+
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/exception/GlobalExceptionHandler.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/exception/GlobalExceptionHandler.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponse;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -24,7 +23,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<BaseResponse> handleCustomException(
             BaseException e, HttpServletRequest request) {
-        log.error("{} is occurred. uri:{}", e.getStatus(), request.getRequestURI());
+        log.error("[CustomException] {} is occurred. uri:{}", e.getStatus(), request.getRequestURI());
 
         return ResponseEntity
                 .badRequest()
@@ -36,7 +35,7 @@ public class GlobalExceptionHandler {
     Validation 처리를 할때 생긴 오류들을 처리한다.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<BaseResponse> handleBadRequestException(
+    public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException (
             MethodArgumentNotValidException e, HttpServletRequest request) {
 
         // 발생한 FiledError 들을 list 에 저장
@@ -44,13 +43,32 @@ public class GlobalExceptionHandler {
         FieldError fieldError = fieldErrors.get(0);   // 첫 번째 에러
         String fieldName = fieldError.getField();  // 필드명
 
-        log.error("fieldName : {} ", fieldName, fieldError.getDefaultMessage() + " uri: {}", request.getRequestURI());
+        log.error("[MethodArgumentNotValidException] fieldName : {} ", fieldName, fieldError.getDefaultMessage() + " uri: {}", request.getRequestURI());
 
         return ResponseEntity
                 .badRequest()
                 .body(new BaseResponse(
                                 HttpStatus.BAD_REQUEST,
                                 fieldError.getDefaultMessage()
+                        )
+                );
+    }
+
+    /*
+    RuntimeException Handler
+    1. PathVariable, RequestParam validation 처리를 할때 생긴 오류들을 처리한다.
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<BaseResponse> handleRuntimeException (
+            RuntimeException e, HttpServletRequest request) {
+
+        log.error("[RuntimeException] {} is occurred. uri:{}", e.getMessage(), request.getRequestURI());
+
+        return ResponseEntity
+                .badRequest()
+                .body(new BaseResponse(
+                                HttpStatus.BAD_REQUEST,
+                                e.getMessage()
                         )
                 );
     }

--- a/src/main/java/shop/jnjeaaaat/easyrsv/service/UserService.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/service/UserService.java
@@ -2,10 +2,14 @@ package shop.jnjeaaaat.easyrsv.service;
 
 import shop.jnjeaaaat.easyrsv.domain.dto.user.AuthChangeRequest;
 import shop.jnjeaaaat.easyrsv.domain.dto.user.AuthChangeResponse;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserDto;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserModifyRequest;
 
 public interface UserService {
 
     AuthChangeResponse addAuthToUser(AuthChangeRequest request);
+
+    UserDto modifyUserDetails(Long userId, UserModifyRequest request);
 
 
 }

--- a/src/main/java/shop/jnjeaaaat/easyrsv/service/impl/UserServiceImpl.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/service/impl/UserServiceImpl.java
@@ -7,11 +7,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.jnjeaaaat.easyrsv.domain.dto.user.AuthChangeRequest;
 import shop.jnjeaaaat.easyrsv.domain.dto.user.AuthChangeResponse;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserDto;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserModifyRequest;
 import shop.jnjeaaaat.easyrsv.domain.model.User;
 import shop.jnjeaaaat.easyrsv.domain.repository.UserRepository;
 import shop.jnjeaaaat.easyrsv.exception.BaseException;
 import shop.jnjeaaaat.easyrsv.service.UserService;
 import shop.jnjeaaaat.easyrsv.utils.JwtTokenProvider;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.*;
 
@@ -64,6 +69,8 @@ public class UserServiceImpl implements UserService {
             log.info("[addPartnerAuthToUser] 파트너 권한 추가 완료");
         }
 
+        user.setUpdatedAt(LocalDateTime.now());
+
         // 새로운 권한을 추가한 새로운 토큰 발행
         String newToken =
                 jwtTokenProvider
@@ -76,6 +83,39 @@ public class UserServiceImpl implements UserService {
                 .name(user.getName())
                 .roles(user.getRoles())
                 .newToken(newToken)
+                .build();
+    }
+
+    /*
+    PathVariable 로 userId, Request Dto 에는 비밀번호, 이름이 있다.
+    User 를 조회하고 UserDto 로 가공해서 리턴
+     */
+    @Override
+    @Transactional
+    public UserDto modifyUserDetails(Long userId, UserModifyRequest request) {
+        log.info("[modifyUserDetails] 유저 정보 수정 - 요청한 유저 id : {}", jwtTokenProvider.getUserIdFromToken());
+
+        // 토큰의 userId 와 입력받은 userId 비교 -> 본인만 정보를 수정할 수 있음.
+        if (!Objects.equals(userId, jwtTokenProvider.getUserIdFromToken())) {
+            throw new BaseException(USER_UN_MATCH);
+        }
+
+        // 존재하는 유저인지 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setName(request.getName());
+        user.setUpdatedAt(LocalDateTime.now());
+
+        return UserDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .password(request.getPassword())
+                .name(user.getName())
+                .roles(user.getRoles())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/shop/jnjeaaaat/easyrsv/utils/JwtTokenProvider.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/utils/JwtTokenProvider.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
@@ -142,8 +141,7 @@ public class JwtTokenProvider {
                 .setSigningKey(secretKey)
                 .parseClaimsJws(token) // Jws<Claims>
                 .getBody() // Claims
-                .get("userId", Long.class); // 암호화 되어있는 email 값
-
+                .get("userId", Long.class); // userId 값
     }
 
 

--- a/src/main/java/shop/jnjeaaaat/easyrsv/web/ShopController.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/web/ShopController.java
@@ -2,6 +2,7 @@ package shop.jnjeaaaat.easyrsv.web;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponse;
 import shop.jnjeaaaat.easyrsv.domain.dto.shop.ShopDto;
@@ -17,6 +18,7 @@ import java.util.List;
 import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.*;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/easy-rsv/v1/shop")

--- a/src/main/java/shop/jnjeaaaat/easyrsv/web/UserController.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/web/UserController.java
@@ -2,17 +2,22 @@ package shop.jnjeaaaat.easyrsv.web;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponse;
 import shop.jnjeaaaat.easyrsv.domain.dto.user.AuthChangeRequest;
 import shop.jnjeaaaat.easyrsv.domain.dto.user.AuthChangeResponse;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserDto;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserModifyRequest;
 import shop.jnjeaaaat.easyrsv.service.UserService;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 
 import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.*;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/easy-rsv/v1/user")
@@ -35,6 +40,18 @@ public class UserController {
                 SUCCESS_ADD_PARTNER_AUTH,
                 response
         );
+    }
 
+    @PutMapping("/{userId}")
+    public BaseResponse<UserDto> modifyUserDetails(
+            @Min(1) @PathVariable Long userId,
+            @RequestBody UserModifyRequest request) {
+
+        log.info("[modifyUserDetails] 유저 정보 수정 요청");
+
+        return new BaseResponse<>(
+                SUCCESS_MODIFY_USER,
+                userService.modifyUserDetails(userId, request)
+        );
     }
 }


### PR DESCRIPTION
Changes
---
1. Modify User API
   - 유저 수정을 위한 Controller, Service 구현
      - token 비교를 Service단에서 해도 정상적으로 동작
2. SecurityConfig 수정
   - antMatcher의 hasAnyRole() 수정

Discuss
---
Service 단에서 `HttpServletRequest` class가 동작하는지 테스트 해봤는데  
정상적으로 `Header` 값을 받아올 수 있어서 `Controller`의 코드가 간단해질 수 있다.

`antMatchers.hasAnyRole()` 에는 "USER" 하나의 권한만 가지고 있어도  
등록해놓은 API에 모두 접근할 수 있게 되는것을 새로 알았다.

유저 권한은 이미 List 형태로 여러권한을 갖을 수 있도록 해놓았고 **처음에 무조건 "USER" 권한**을 갖게 되기 때문에  
`antMatchers` 마다 "ADMIN"을 붙여주지 않아도 **"USER" 권한만 가지고도 API에 접근**할 수 있다.

Issues
---
Resolves: #3