### PR TITLE
Feat: [011-RESERVATION-ADD] "(추가) 상점 예약 추가"

### DIFF
--- a/src/main/java/shop/jnjeaaaat/easyrsv/config/security/SecurityConfig.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/config/security/SecurityConfig.java
@@ -60,6 +60,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.PUT, "easy-rsv/v1/shop/**").hasAnyRole("PARTNER")
                 .antMatchers(HttpMethod.DELETE, "easy-rsv/v1/shop/**").hasAnyRole("PARTNER")
 
+                // 예약 관련 API
+                .antMatchers("/easy-rsv/v1/reservation/**").hasAnyRole("USER")
+
                 .antMatchers("**exception**").permitAll()
 
                 .anyRequest().hasRole("ADMIN")

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponseStatus.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponseStatus.java
@@ -26,6 +26,8 @@ public enum BaseResponseStatus {
 
     SUCCESS_MODIFY_USER(OK.value(), "유저 정보를 수정하였습니다."),
 
+    // reservation
+    SUCCESS_ADD_RESERVATION(OK.value(), "상점을 예약하였습니다."),
 
     //// Exception
     // shop
@@ -38,6 +40,9 @@ public enum BaseResponseStatus {
     PASSWORD_UN_MATCH(BAD_REQUEST.value(), "비밀번호가 다릅니다."),
     ALREADY_ADMIN_ACCOUNT(BAD_REQUEST.value(), "이미 관리자 계정입니다."),
     ALREADY_PARTNER_ACCOUNT(BAD_REQUEST.value(), "이미 이지랩 파트너 입니다."),
+
+    // reserve
+    OWNER_CANT_RESERVE(BAD_REQUEST.value(), "본인 상점은 예약할 수 없습니다."),
 
     // token
     EMPTY_JWT(UNAUTHORIZED.value(), "토큰을 등록해주세요."),

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationDto.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationDto.java
@@ -1,0 +1,37 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.reservation;
+
+import lombok.*;
+import shop.jnjeaaaat.easyrsv.domain.model.Reservation;
+import shop.jnjeaaaat.easyrsv.domain.model.Shop;
+import shop.jnjeaaaat.easyrsv.domain.model.User;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationDto {
+
+    private Long id;  // 예약 번호
+    private User user;  // 예약한 유저
+    private Shop shop;  // 예약한 상점
+    private LocalDateTime reservationDate;  // 예약 날짜
+    private boolean isApproved;  // 승인 여부
+
+    private LocalDateTime createdAt;  // 예약을 한 시간
+    private LocalDateTime updatedAt;  // 예약 정보 변경 시간
+
+    public static ReservationDto from(Reservation reservation) {
+        return ReservationDto.builder()
+                .id(reservation.getId())// 예약 번호
+                .user(reservation.getUser())  // 예약한 유저
+                .shop(reservation.getShop())  // 예약한 상점
+                .reservationDate(reservation.getReservationDate())  // 예약 날짜
+                .isApproved(reservation.isApproved())  // 승인 여부
+                .createdAt(reservation.getCreatedAt())  // 예약을 한 시간
+                .updatedAt(reservation.getUpdatedAt())  // 예약 정보 변경 시간
+                .build();
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputRequest.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputRequest.java
@@ -1,0 +1,31 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.reservation;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.Positive;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationInputRequest {
+
+    // 예약하는 유저 id
+    @Positive
+    private Long userId;
+
+    // 예약하는 상점 id
+    @Positive
+    private Long shopId;
+
+    // 예약 날짜
+    // 마지막 ss (초) 는 00으로 고정값
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reservationDate;
+
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputResponse.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputResponse.java
@@ -1,0 +1,29 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.reservation;
+
+import lombok.*;
+import shop.jnjeaaaat.easyrsv.domain.dto.shop.ReservedShopInform;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReservationInputResponse {
+    private String email; // 예약한 유저 email
+    private ReservedShopInform shop;  // 예약한 상점
+    private LocalDateTime reservationDate;   // 예약날짜
+
+    // ReservationInputResponse 에서 필요한 정보만 return
+    public static ReservationInputResponse from(ReservationDto dto) {
+        return ReservationInputResponse.builder()
+                .email(dto.getUser().getEmail())  // 예약한 유저 email
+                .shop(ReservedShopInform.builder()
+                        .name(dto.getShop().getName())  // 상점 이름만
+                        .location(dto.getShop().getLocation())  // 상점 위치만
+                        .build())
+                .reservationDate(dto.getReservationDate())   // 예약날짜
+                .build();
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ReservedShopInform.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ReservedShopInform.java
@@ -1,0 +1,17 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.shop;
+
+import lombok.*;
+
+/**
+ * 사용자가 상점을 예약하고 정상적으로 예약이 되었다면
+ * 받아서 확인할 수 있는 정보 Class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservedShopInform {
+    private String name;
+    private String location;
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDeleteRequest.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDeleteRequest.java
@@ -4,6 +4,9 @@ import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
+/**
+ * 상점을 삭제할 때 입력해야 하는 Request Class
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDeleteResponse.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDeleteResponse.java
@@ -2,6 +2,10 @@ package shop.jnjeaaaat.easyrsv.domain.dto.shop;
 
 import lombok.*;
 
+/**
+ * 상점을 삭제하고 나서 정상적으로 삭제가 되었는지
+ * 사용자가 확인할 수 있는 Class
+ */
 @Getter
 @Setter
 @AllArgsConstructor

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDto.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDto.java
@@ -6,6 +6,9 @@ import shop.jnjeaaaat.easyrsv.domain.model.Shop;
 
 import java.time.LocalDateTime;
 
+/**
+ * 사용자에 가깝게 Shop Entity 를 가공한 DTO Class
+ */
 @Getter
 @Setter
 @Builder

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopInputResponse.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopInputResponse.java
@@ -2,6 +2,10 @@ package shop.jnjeaaaat.easyrsv.domain.dto.shop;
 
 import lombok.*;
 
+/**
+ * 상점 등록하고 나서 정상적으로 등록되었는지
+ * 사용자가 확인할 수 있는 정보 Class
+ */
 @Getter
 @Setter
 @Builder

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/model/Reservation.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/model/Reservation.java
@@ -1,0 +1,37 @@
+package shop.jnjeaaaat.easyrsv.domain.model;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+@Entity
+public class Reservation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 유저 한명이 여러개의 예약을 등록할 수 있음
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 한 상점당 여러개의 예약이 등록될 수 있음
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
+
+    // 예약 날짜
+    @Column(nullable = false)
+    private LocalDateTime reservationDate;
+
+    @Column(nullable = false)
+    private boolean isApproved;
+
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/repository/ReservationRepository.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package shop.jnjeaaaat.easyrsv.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import shop.jnjeaaaat.easyrsv.domain.model.Reservation;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/service/ReservationService.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/service/ReservationService.java
@@ -1,0 +1,10 @@
+package shop.jnjeaaaat.easyrsv.service;
+
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputRequest;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputResponse;
+
+public interface ReservationService {
+
+    ReservationInputResponse reserveShop(ReservationInputRequest request);
+
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/service/impl/ReservationServiceImpl.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/service/impl/ReservationServiceImpl.java
@@ -1,0 +1,75 @@
+package shop.jnjeaaaat.easyrsv.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationDto;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputRequest;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputResponse;
+import shop.jnjeaaaat.easyrsv.domain.model.Reservation;
+import shop.jnjeaaaat.easyrsv.domain.model.Shop;
+import shop.jnjeaaaat.easyrsv.domain.model.User;
+import shop.jnjeaaaat.easyrsv.domain.repository.ReservationRepository;
+import shop.jnjeaaaat.easyrsv.domain.repository.ShopRepository;
+import shop.jnjeaaaat.easyrsv.domain.repository.UserRepository;
+import shop.jnjeaaaat.easyrsv.exception.BaseException;
+import shop.jnjeaaaat.easyrsv.service.ReservationService;
+import shop.jnjeaaaat.easyrsv.utils.JwtTokenProvider;
+
+import java.util.Objects;
+
+import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationServiceImpl implements ReservationService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ReservationRepository reservationRepository;
+    private final ShopRepository shopRepository;
+    private final UserRepository userRepository;
+
+    /*
+    상점 예약 등록
+    유저 id, 상점 id, 예약 날짜 받아서 상점 예약
+     */
+    @Override
+    public ReservationInputResponse reserveShop(ReservationInputRequest request) {
+
+        // 토큰으로부터 userId 받아오기
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        log.info("[reserveShop] 상점 예약 -" +
+                " 예약한 유저 id : {}, 예약한 상점 id : {}", userId, request.getShopId());
+        // Shop 존재 유무 체크
+        Shop shop = shopRepository.findById(request.getShopId())
+                .orElseThrow(() -> new BaseException(SHOP_NOT_FOUND));
+        // User 존재 유무 체크
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+        // 예약한 사람과 token userId 가 다를 때
+        if (!Objects.equals(userId, user.getId())) {
+            throw new BaseException(USER_UN_MATCH);
+        }
+        // 예약한 사람이 상점 주인일 때
+        if (Objects.equals(request.getUserId(), shop.getOwner().getId())) {
+            throw new BaseException(OWNER_CANT_RESERVE);
+        }
+        // todo: 해당 상점에 이미 예약한 유저일 때
+
+        // 승인 여부는 false 로 고정값
+        ReservationDto reservationDto =
+                ReservationDto.from(reservationRepository.save(
+                                Reservation.builder()
+                                        .user(user)
+                                        .shop(shop)
+                                        .reservationDate(request.getReservationDate())
+                                        .isApproved(false)
+                                        .build()
+                        )
+                );
+
+        return ReservationInputResponse.from(reservationDto);
+    }
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/web/ReservationController.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/web/ReservationController.java
@@ -1,0 +1,37 @@
+package shop.jnjeaaaat.easyrsv.web;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponse;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputRequest;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputResponse;
+import shop.jnjeaaaat.easyrsv.service.ReservationService;
+
+import javax.validation.Valid;
+
+import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.SUCCESS_ADD_RESERVATION;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/easy-rsv/v1/reservation")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping("")
+    public BaseResponse<ReservationInputResponse> reserveShop(
+            @Valid @RequestBody ReservationInputRequest request) {
+
+        log.info("[reserveShop] 상점 예약 요청 ");
+
+        return new BaseResponse<>(
+                SUCCESS_ADD_RESERVATION,
+                reservationService.reserveShop(request)
+        );
+    }
+}


### PR DESCRIPTION
Changes
---
POST reservation API

1. POST reservation API
   - 상점 예약 Entity, Dto 생성
      - Reservation Entity, 기본 Dto
         - id, 유저, 상점, 예약 날짜/시간, 승인 여부
      - ReservationInputRequest
         - 유저 id, 상점 id, 예약할 날짜/시간(DateForm 이용)
      - ReservationInputResponse
         - 유저 email, 상점 inform 별도로 생성, 예약 날짜/시간

Discuss
---
누가 예약했는지에 대한 User 정보와,
어떤 상점을 예약했는지에 대한 Shop 정보를 다같이 다뤄야해서 코드가 복잡해지는 중이다..

최대한 package를 분리하고 보기좋은 코드를 짜기위해 노력하고 있다.

Execution
---
- 정상실행
![image](https://github.com/jnjeaaaat/easy-rsv/assets/47658862/10522686-6449-4b63-963a-fb43913e612c)

- 에러
![image](https://github.com/jnjeaaaat/easy-rsv/assets/47658862/0842cc98-1893-42a1-b794-c34bc6eb978b)


Issues
---
#14