### PR TITLE
Feat: [013-RESERVATION-GET&PUT] "(추가) 예약 수정, 여러 종류의 조회 추가"

### DIFF
--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponseStatus.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/base/BaseResponseStatus.java
@@ -29,11 +29,16 @@ public enum BaseResponseStatus {
     // reservation
     SUCCESS_ADD_RESERVATION(OK.value(), "상점을 예약하였습니다."),
     SUCCESS_CANCEL_RESERVATION(OK.value(), "상점 예약을 취소하였습니다."),
+    SUCCESS_MODIFY_RESERVATION(OK.value(), "예약 정보를 변경하였습니다."),
+    GET_MY_RESERVATION_LIST(OK.value(), "나의 예약 정보 리스트를 조회하였습니다."),
+    GET_SHOP_RESERVATION_LIST(OK.value(), "상점 예약 리스트를 조회하였습니다."),
+    GET_RESERVATION_BY_ID(OK.value(), "예약 정보를 조회하였습니다."),
 
-    //// Exception
+    ///////////////////////////////// Exception ////////////////////////////////
     // shop
     SHOP_NOT_FOUND(BAD_REQUEST.value(), "해당 상점이 없습니다."),
     CHECK_MESSAGE_UN_MATCH(BAD_REQUEST.value(), "삭제 확인 문구가 잘못되었습니다."),
+    NOT_OWNER(BAD_REQUEST.value(), "해당 상점의 주인이 아닙니다."),
 
     // user
     USER_NOT_FOUND(BAD_REQUEST.value(), "해당 유저가 없습니다."),
@@ -44,7 +49,11 @@ public enum BaseResponseStatus {
 
     // reserve
     OWNER_CANT_RESERVE(BAD_REQUEST.value(), "본인 상점은 예약할 수 없습니다."),
+    ALREADY_RESERVATED(BAD_REQUEST.value(), "이미 예약한 상점입니다."),
     RESERVATION_NOT_FOUND(BAD_REQUEST.value(), "예약된 내역이 없습니다."),
+    MODIFY_JUST_ME(BAD_REQUEST.value(), "본인만 예약을 변경할 수 있습니다."),
+    MODIFY_JUST_THAT_SHOP(BAD_REQUEST.value(), "예약한 상점이 아닙니다."),
+    NO_AUTH_TO_BROWSE(BAD_REQUEST.value(), "예약 정보를 조회할 권한이 없습니다."),
 
     // token
     EMPTY_JWT(UNAUTHORIZED.value(), "토큰을 등록해주세요."),

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationDto.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationDto.java
@@ -1,12 +1,19 @@
 package shop.jnjeaaaat.easyrsv.domain.dto.reservation;
 
 import lombok.*;
+import shop.jnjeaaaat.easyrsv.domain.dto.shop.ShopSimpleInform;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.OwnerInform;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.UserSimpleInform;
 import shop.jnjeaaaat.easyrsv.domain.model.Reservation;
 import shop.jnjeaaaat.easyrsv.domain.model.Shop;
 import shop.jnjeaaaat.easyrsv.domain.model.User;
 
 import java.time.LocalDateTime;
 
+/**
+ * 예약 정보에 대한 Reservation Entity 를
+ * 사용자에 가깝게 가공한 Dto Class
+ */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -15,8 +22,8 @@ import java.time.LocalDateTime;
 public class ReservationDto {
 
     private Long id;  // 예약 번호
-    private User user;  // 예약한 유저
-    private Shop shop;  // 예약한 상점
+    private UserSimpleInform user;  // 예약한 유저
+    private ShopSimpleInform shop;  // 예약한 상점
     private LocalDateTime reservationDate;  // 예약 날짜
     private boolean isApproved;  // 승인 여부
 
@@ -24,10 +31,28 @@ public class ReservationDto {
     private LocalDateTime updatedAt;  // 예약 정보 변경 시간
 
     public static ReservationDto from(Reservation reservation) {
+        Shop shop = reservation.getShop();
+        User user = reservation.getUser();
+
         return ReservationDto.builder()
-                .id(reservation.getId())// 예약 번호
-                .user(reservation.getUser())  // 예약한 유저
-                .shop(reservation.getShop())  // 예약한 상점
+                .id(reservation.getId())  // 예약 번호
+                .user(UserSimpleInform.builder()  // 예약한 유저
+                        .id(user.getId())
+                        .email(user.getEmail())
+                        .name(user.getName())
+                        .build())
+                .shop(ShopSimpleInform.builder()   // 예약한 상점
+                        .id(shop.getId())
+                        .name(shop.getName())
+                        .description(shop.getDescription())
+                        .location(shop.getLocation())
+                        .owner(OwnerInform.builder()
+                                .id(shop.getOwner().getId())
+                                .email(shop.getOwner().getEmail())
+                                .name(shop.getOwner().getName())
+                                .build())
+                        .createdAt(shop.getCreatedAt())
+                        .build())
                 .reservationDate(reservation.getReservationDate())  // 예약 날짜
                 .isApproved(reservation.isApproved())  // 승인 여부
                 .createdAt(reservation.getCreatedAt())  // 예약을 한 시간

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputRequest.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputRequest.java
@@ -7,6 +7,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.Positive;
 import java.time.LocalDateTime;
 
+/**
+ * 예약을 추가할 때 필요한 Request Class
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputResponse.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/reservation/ReservationInputResponse.java
@@ -5,6 +5,9 @@ import shop.jnjeaaaat.easyrsv.domain.dto.shop.ReservedShopInform;
 
 import java.time.LocalDateTime;
 
+/**
+ * 상점 예약 후 받을 수 있는 Response Class
+ */
 @Getter
 @Setter
 @AllArgsConstructor

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDto.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopDto.java
@@ -36,6 +36,7 @@ public class ShopDto {
                 .description(shop.getDescription())
                 .location(shop.getLocation())
                 .owner(OwnerInform.builder()
+                        .id(shop.getOwner().getId())
                         .email(shop.getOwner().getEmail())
                         .name(shop.getOwner().getName())
                         .build())

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopSimpleInform.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/shop/ShopSimpleInform.java
@@ -1,0 +1,24 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.shop;
+
+import lombok.*;
+import shop.jnjeaaaat.easyrsv.domain.dto.user.OwnerInform;
+
+import java.time.LocalDateTime;
+
+/**
+ * 다른 Entity 에서 Shop 에 대한 정보가 필요할 때
+ * 사용자가 필요한 내용만 보여줄 수 있는 Shop 간략정보 Class
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class ShopSimpleInform {
+    private Long id;
+    private String name;
+    private String description;
+    private String location;
+    private OwnerInform owner;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/user/OwnerInform.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/user/OwnerInform.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 @Builder
 public class OwnerInform {
+    private Long id;
     private String email;
     private String name;
 }

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/user/UserSimpleInform.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/dto/user/UserSimpleInform.java
@@ -1,0 +1,18 @@
+package shop.jnjeaaaat.easyrsv.domain.dto.user;
+
+import lombok.*;
+
+/**
+ * 다른 Entity 에서 Shop 에 대한 정보가 필요할 때
+ * 사용자가 필요한 내용만 보여줄 수 있는 User 간략정보 Class
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class UserSimpleInform {
+    private Long id;
+    private String email;
+    private String name;
+}

--- a/src/main/java/shop/jnjeaaaat/easyrsv/domain/repository/ReservationRepository.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/domain/repository/ReservationRepository.java
@@ -3,7 +3,19 @@ package shop.jnjeaaaat.easyrsv.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import shop.jnjeaaaat.easyrsv.domain.model.Reservation;
+import shop.jnjeaaaat.easyrsv.domain.model.Shop;
+import shop.jnjeaaaat.easyrsv.domain.model.User;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Optional<Reservation> findByUserAndShop(User user, Shop shop);
+
+    List<Reservation> findAllByUser(User user);
+
+    List<Reservation> findAllByShop(Shop shop);
+
+
 }

--- a/src/main/java/shop/jnjeaaaat/easyrsv/service/ReservationService.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/service/ReservationService.java
@@ -1,12 +1,41 @@
 package shop.jnjeaaaat.easyrsv.service;
 
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationDto;
 import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputRequest;
 import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputResponse;
 
+import java.util.List;
+
 public interface ReservationService {
 
+    /**
+     * 상점 예약 등록
+     */
     ReservationInputResponse reserveShop(ReservationInputRequest request);
 
+    /**
+     * 예약 정보 변경 - 날짜만 변경
+     */
+    ReservationInputResponse modifyReservation(Long reservationId, ReservationInputRequest request);
+
+    /**
+     * 본인이 예약한 예약 리스트 return
+     */
+    List<ReservationDto> getMyReservations(Long userId);
+
+    /**
+     * 본인 상점에 예약된 예약 리스트 return
+     */
+    List<ReservationDto> getMyShopReservations(Long shopId);
+
+    /**
+     * 하나의 예약 정보 조회
+     */
+    ReservationDto getReservation(Long reservationId);
+
+    /**
+     * 예약 취소
+     */
     void cancelReservation(Long reservationId);
 
 }

--- a/src/main/java/shop/jnjeaaaat/easyrsv/web/ReservationController.java
+++ b/src/main/java/shop/jnjeaaaat/easyrsv/web/ReservationController.java
@@ -2,8 +2,10 @@ package shop.jnjeaaaat.easyrsv.web;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponse;
+import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationDto;
 import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputRequest;
 import shop.jnjeaaaat.easyrsv.domain.dto.reservation.ReservationInputResponse;
 import shop.jnjeaaaat.easyrsv.service.ReservationService;
@@ -11,10 +13,12 @@ import shop.jnjeaaaat.easyrsv.service.ReservationService;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 
-import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.SUCCESS_ADD_RESERVATION;
-import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.SUCCESS_CANCEL_RESERVATION;
+import java.util.List;
+
+import static shop.jnjeaaaat.easyrsv.domain.dto.base.BaseResponseStatus.*;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/easy-rsv/v1/reservation")
@@ -35,6 +39,72 @@ public class ReservationController {
         return new BaseResponse<>(
                 SUCCESS_ADD_RESERVATION,
                 reservationService.reserveShop(request)
+        );
+    }
+
+    /*
+    예약 id 값 받아서
+    예약한 본인이 맞는지, 예약한 상점이 맞는지 확인 후
+    예약 정보 변경
+     */
+    @PutMapping("/{reservationId}")
+    public BaseResponse<ReservationInputResponse> modifyReservation(
+            @PathVariable @Positive Long reservationId,
+            @Valid @RequestBody ReservationInputRequest request) {
+
+        log.info("[modifyReservation] 예약 정보 변경 (날짜)");
+
+        return new BaseResponse<>(
+                SUCCESS_MODIFY_RESERVATION,
+                reservationService.modifyReservation(reservationId, request)
+        );
+    }
+
+    /*
+    유저 id 값 받아서
+    본인이 예약한 예약 정보 리스트 조회
+     */
+    @GetMapping("/user/{userId}")
+    public BaseResponse<List<ReservationDto>> getMyReservations(
+            @PathVariable @Positive Long userId) {
+
+        log.info("[getMyReservations] 본인이 예약한 예약 정보 리스트 요청");
+
+        return new BaseResponse<>(
+                GET_MY_RESERVATION_LIST,
+                reservationService.getMyReservations(userId)
+        );
+    }
+
+    /*
+    유저 id 값 받아서
+    본인 상점에 대한 예약 정보 리스트 조회
+     */
+    @GetMapping("/shop/{shopId}")
+    public BaseResponse<List<ReservationDto>> getMyShopReservations(
+            @PathVariable @Positive Long shopId) {
+
+        log.info("[getMyShopReservations] 본인 상점의 예약 정보 리스트 요청");
+
+        return new BaseResponse<>(
+                GET_SHOP_RESERVATION_LIST,
+                reservationService.getMyShopReservations(shopId)
+        );
+    }
+
+    /*
+    예약 id 값 받아서
+    본인이 예약한 정보나, 본인 상점의 예약한 정보 조회 가능
+     */
+    @GetMapping("/{reservationId}")
+    public BaseResponse<ReservationDto> getReservation(
+            @PathVariable @Positive Long reservationId) {
+
+        log.info("[getReservation] 해당 예약 정보 요청");
+
+        return new BaseResponse<>(
+                GET_RESERVATION_BY_ID,
+                reservationService.getReservation(reservationId)
         );
     }
 


### PR DESCRIPTION
Changes
---
GET reservation APIs
PUT reservation API

1. GET `나의 예약 정보 리스트` API
   - 유저 id 값 받아서 예약 리스트 조회
      - 본인이 예약한게 맞는지 확인
2. GET `나의 상점의 예약 정보 리스트` API
   - 상점 id 값 받아서 예약 리스트 조회
      - 본인의 상점을 조회하고 있는게 맞는지 확인
      - `PARTNER` 권한이 없어도 본인 상점 확인 validation 에서 처리
3. GET `하나의 예약 정보 조회` API
   - 예약 id 값 받아서 예약 조회
      - 본인의 예약이 맞는지, 상점 주인이 맞는지 확인
      - 누가 조회했는지 log 로 email 확인한다.
4. UserSimpleInform, ShopSimpleInform 생성
   - GET API 들에서 리턴하는 `ReservationDto` 에 `User`, `Shop` 자체가 들어가있어서  
     ***디테일한 정보까지 모두 사용자에게 노출***되는 문제 때문에
     따로 `Information` 클래스 생성

Discuss
---
JPA method 중에 `findByUser` or `findByShop` 매개변수로
`userId`, `shopId` 이 아닌 `User`, `Shop` 엔티티 자체를 넣어줘야 하는데
***컴파일상에는 문제가 없어서*** `exception`이 발생했을 때 어떤 오류인지 단번에 알아채기 힘든 문제다.

`userRepository`, `shopRepository`에서 `findBy`로 `Entity`를 먼저 받아오고 나서
`reservationRepository`의 `findByUserAndShop()` 메서드의 매개변수로 넣어줘야 한다는 것을 주의하자..!

Issues
---
Resolve: #14